### PR TITLE
Increase throughput for GPT-4.1-nano

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -97,7 +97,10 @@ def run(cfg_path: Path, dry_run: bool = False) -> None:
             for mdl in spec["models"]:
                 model_id     = mdl["id"]
                 price_per_1k = mdl["price_per_1k_tokens"]
-                max_calls    = mdl["max_calls_per_min"]
+                if model_id == "gpt-4.1-nano":
+                    max_calls = 250
+                else:
+                    max_calls = mdl.get("max_calls_per_min", 60)
 
                 # projected cost guard
                 if not dry_run:

--- a/wrappers/one_call_trial.py
+++ b/wrappers/one_call_trial.py
@@ -3,7 +3,7 @@
 import csv, os, pathlib, re, sys, time
 import openai
 from openai import OpenAI
-from .rate_limit import wait_one_second
+from .rate_limit import wait_one_second, set_tpm
 
 MODEL = "gpt-4o-mini"
 PRICE_PER_1K = 0.003
@@ -21,12 +21,14 @@ if api_key is None:
     sys.exit("OPENAI_API_KEY env var missing")
 
 client = OpenAI(api_key=api_key)
+set_tpm(60)
 
 wait_one_second()
 resp = client.chat.completions.create(
     model=MODEL,
     messages=[{"role": "user", "content": prompt_text}],
     temperature=0,
+    max_tokens=1000,
 )
 
 reply_text = resp.choices[0].message.content.strip()

--- a/wrappers/openai_v1.py
+++ b/wrappers/openai_v1.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from openai import OpenAI
 import os, backoff, openai
-from .rate_limit import wait_one_second
+from .rate_limit import wait_one_second, set_tpm
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+set_tpm(60)
 
 @backoff.on_exception(backoff.expo,
                     (openai.RateLimitError, openai.APIError),
@@ -18,6 +19,7 @@ def chat_once(model: str, prompt: str, temperature: float = 0.0):
         model=model,
         messages=[{"role": "user", "content": prompt}],
         temperature=temperature,
+        max_tokens=1000,
     )
     msg = resp.choices[0].message.content.strip()
     u = resp.usage

--- a/wrappers/rate_limit.py
+++ b/wrappers/rate_limit.py
@@ -3,13 +3,22 @@ from threading import Lock
 
 _last_time = 0.0
 _lock = Lock()
+_min_interval = 1.0
+
+def set_tpm(tpm: int) -> None:
+    """Adjust the minimum delay based on requests per minute."""
+    global _min_interval
+    if tpm <= 0:
+        _min_interval = 1.0
+    else:
+        _min_interval = min(60.0 / tpm, 1.0)
 
 def wait_one_second():
-    """Block until at least one second has passed since the last call."""
+    """Block until `_min_interval` seconds have passed since the last call."""
     global _last_time
     with _lock:
         now = time.monotonic()
         elapsed = now - _last_time
-        if elapsed < 1.0:
-            time.sleep(1.0 - elapsed)
+        if elapsed < _min_interval:
+            time.sleep(_min_interval - elapsed)
         _last_time = time.monotonic()

--- a/wrappers/run_llm_json.py
+++ b/wrappers/run_llm_json.py
@@ -13,7 +13,7 @@ from typing import Dict, List
 from openai import OpenAI, RateLimitError, APIError
 import backoff
 import re
-from .rate_limit import wait_one_second
+from .rate_limit import wait_one_second, set_tpm
 
 from generate import ECAProblemGenerator, Problem1D
 from rules import Rule1D
@@ -48,6 +48,7 @@ def chat_json(model: str, prompt: str, temperature: float = 0.0):
         messages=[{"role": "user", "content": prompt}],
         response_format={"type": "json_object"},  # JSON mode
         temperature=temperature,
+        max_tokens=1000,
     )
 
     raw = resp.choices[0].message.content
@@ -76,6 +77,9 @@ def main() -> None:
     ap.add_argument("--tpm", type=int, default=60, help="max calls / minute")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
+
+    # adjust internal rate limiter
+    set_tpm(args.tpm)
 
     # only initialize the client if we're doing a real run
     global client

--- a/wrappers/run_llm_json_2d.py
+++ b/wrappers/run_llm_json_2d.py
@@ -18,7 +18,7 @@ from typing import Dict, List
 
 from openai import OpenAI, RateLimitError, APIError
 import backoff
-from .rate_limit import wait_one_second
+from .rate_limit import wait_one_second, set_tpm
 
 from generate import CAProblemGenerator2D, Problem2D
 from rules import Rule2D
@@ -51,6 +51,7 @@ def chat_json(model: str, prompt: str, temperature: float = 0.0):
         messages=[{"role": "user", "content": prompt}],
         response_format={"type": "json_object"},
         temperature=temperature,
+        max_tokens=1000,
     )
 
     raw = resp.choices[0].message.content
@@ -92,6 +93,9 @@ def main() -> None:
     ap.add_argument("--tpm", type=int, default=60, help="max calls / minute")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
+
+    # adjust rate limiter according to target RPM
+    set_tpm(args.tpm)
 
     # only initialize the client if this is not a dry run
     global client


### PR DESCRIPTION
## Summary
- tune `wait_one_second` so delay depends on target rate
- expose `set_tpm` and hook it up in wrappers
- default orchestrator to 250 requests/min for gpt-4.1-nano
- limit OpenAI requests to 1000 tokens per call

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa57f9ab083309cd363d8ec310484