### PR TITLE
Fix timesteps list handling in 1D batch prompt

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -242,6 +242,8 @@ class ECAProblemGenerator:
         if isinstance(timesteps, int):
             timestep_list = [timesteps] * len(problem_list)
         else:
-            if len(timesteps) < len(problem_list):
+            timestep_list = list(timesteps)
+            if len(timestep_list) != len(problem_list):
                 raise ValueError("Length of timesteps must equal the number of problems.")
+
         return [self.generate_prompt_1D(problem_list[i], timestep_list[i]) for i in range(len(problem_list))]

--- a/tests/test_generator_1d.py
+++ b/tests/test_generator_1d.py
@@ -71,3 +71,14 @@ def test_generate_prompt_batch_length():
     # ensure ordering is preserved
     for p_obj, p_txt in zip(probs, prompts):
         assert str(p_obj.start_state) in p_txt
+
+
+def test_generate_prompt_batch_list_timesteps():
+    gen = ECAProblemGenerator(state_size=6, seed=3, density=0.4)
+    probs = gen.generate_batch(3, timesteps=1)
+    timesteps = [1, 2, 3]
+    prompts = gen.generate_prompt_1d_batch(probs, timesteps)
+
+    assert len(prompts) == len(probs)
+    for prompt, t in zip(prompts, timesteps):
+        assert f"After {t} timestep" in prompt


### PR DESCRIPTION
## Summary
- ensure `generate_prompt_1d_batch` converts timesteps sequences to lists and checks length
- add regression test for list timesteps

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702d0040ec833091a3e8299d578165