### PR TITLE
Improve run_llm_json logging and resume

### DIFF
--- a/wrappers/run_llm_json_2d.py
+++ b/wrappers/run_llm_json_2d.py
@@ -44,7 +44,7 @@ def extract_json_from_string(s: str) -> dict | None:
 
 @backoff.on_exception(backoff.expo, (RateLimitError, APIError), max_time=60)
 def chat_json(model: str, prompt: str, temperature: float = 0.0):
-    """One JSON-mode chat completion → (python_dict, usage_dict)."""
+    """One JSON-mode chat completion → (python_dict, usage_dict, raw_text)."""
     wait_one_second()
     resp = client.chat.completions.create(
         model=model,
@@ -70,7 +70,7 @@ def chat_json(model: str, prompt: str, temperature: float = 0.0):
         "completion": u.completion_tokens,
         "total": u.total_tokens,
     }
-    return parsed, usage
+    return parsed, usage, raw
 
 def reconstruct_problem(record: Dict) -> Problem2D:
     """Rebuild a Problem2D from a JSON dict in the dataset."""
@@ -92,6 +92,8 @@ def main() -> None:
     ap.add_argument("--temperature", type=float, default=0.0)
     ap.add_argument("--tpm", type=int, default=60, help="max calls / minute")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--raw-log", type=pathlib.Path,
+                    help="File to append raw model responses")
     args = ap.parse_args()
 
     # adjust rate limiter according to target RPM
@@ -104,9 +106,24 @@ def main() -> None:
         if client.api_key is None:
             sys.exit("OPENAI_API_KEY env var not set")
 
+    total_records = sum(1 for _ in args.input.open())
+
     # resume capability
-    done = args.output.exists() and sum(1 for _ in args.output.open())
-    out_jsonl = args.output.open("a", encoding="utf-8")
+    done = 0
+    out_mode = "a"
+    if args.output.exists():
+        done = sum(1 for _ in args.output.open())
+        if done > total_records:
+            print(
+                f"[info] existing prediction file has {done} lines; dataset has {total_records}. Starting fresh"
+            )
+            done = 0
+            out_mode = "w"
+    out_jsonl = args.output.open(out_mode, encoding="utf-8")
+    raw_log_path = args.raw_log if args.raw_log else args.output.with_suffix(".raw")
+    raw_log = raw_log_path.open("a", encoding="utf-8")
+    if done:
+        print(f"Resuming — {done} predictions already exist")
 
     usage_csv = args.usage.open("a", newline="")
     writer = csv.writer(usage_csv)
@@ -128,13 +145,15 @@ def main() -> None:
                 out_jsonl.write(json.dumps({"answer": []}) + "\n")
                 continue
 
-            data, usage = chat_json(args.model, prompt, args.temperature)
+            data, usage, raw_txt = chat_json(args.model, prompt, args.temperature)
             usd = usage["total"] / 1000 * PRICE_PER_1K
             running_cost += usd
             if running_cost > HARD_CAP:
                 sys.exit(f"💸 cost {running_cost:.2f} > hard cap ${HARD_CAP}")
 
             out_jsonl.write(json.dumps(data, separators=(",", ":")) + "\n")
+            raw_log.write(raw_txt + "\n")
+            raw_log.flush()
             writer.writerow([
                 time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 args.model,


### PR DESCRIPTION
## Summary
- keep a persistent raw response log for each model call
- reset prediction files if a previous run has more lines than the dataset
- add command line options for raw logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a96fdf048330933c8fd2fea944d8