### PR TITLE
Add global logging of model responses

### DIFF
--- a/wrappers/one_call_trial.py
+++ b/wrappers/one_call_trial.py
@@ -4,6 +4,7 @@ import csv, os, pathlib, re, sys, time
 import openai
 from openai import OpenAI
 from .rate_limit import wait_one_second, set_tpm
+from .response_logger import log_response
 
 MODEL = "gpt-4o-mini"
 PRICE_PER_1K = 0.003
@@ -31,7 +32,9 @@ resp = client.chat.completions.create(
     max_tokens=1000,
 )
 
-reply_text = resp.choices[0].message.content.strip()
+raw_txt = resp.choices[0].message.content
+log_response(MODEL, raw_txt)
+reply_text = raw_txt.strip()
 
 usage = resp.usage
 usd_cost = usage.total_tokens / 1000 * PRICE_PER_1K

--- a/wrappers/openai_v1.py
+++ b/wrappers/openai_v1.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from openai import OpenAI
 import os, backoff, openai
 from .rate_limit import wait_one_second, set_tpm
+from .response_logger import log_response
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 set_tpm(60)
@@ -21,7 +22,9 @@ def chat_once(model: str, prompt: str, temperature: float = 0.0):
         temperature=temperature,
         max_tokens=1000,
     )
-    msg = resp.choices[0].message.content.strip()
+    raw_txt = resp.choices[0].message.content
+    log_response(model, raw_txt)
+    msg = raw_txt.strip()
     u = resp.usage
     usage = {
         "prompt_tokens": u.prompt_tokens,

--- a/wrappers/response_logger.py
+++ b/wrappers/response_logger.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import time
+
+# Path to the global response log file
+LOG_PATH = pathlib.Path("logs") / "responses.log"
+
+
+def log_response(model: str, text: str, *, log_file: pathlib.Path = LOG_PATH) -> None:
+    """Append a record of a model's raw response to the log file.
+
+    Each line is a JSON object with the keys:
+      - ts: ISO timestamp (UTC)
+      - model: model identifier
+      - response: the raw text returned by the model
+    """
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "model": model,
+        "response": text,
+    }
+    with log_file.open("a", encoding="utf-8") as fp:
+        fp.write(json.dumps(entry, ensure_ascii=False) + "\n")
+

--- a/wrappers/run_llm_json.py
+++ b/wrappers/run_llm_json.py
@@ -14,6 +14,7 @@ from openai import OpenAI, RateLimitError, APIError
 import backoff
 import re
 from .rate_limit import wait_one_second, set_tpm
+from .response_logger import log_response
 
 from generate import ECAProblemGenerator, Problem1D
 from rules import Rule1D
@@ -52,6 +53,7 @@ def chat_json(model: str, prompt: str, temperature: float = 0.0):
     )
 
     raw = resp.choices[0].message.content
+    log_response(model, raw)
     parsed = extract_json_from_string(raw)
     if parsed is None:
         print(

--- a/wrappers/run_llm_json_2d.py
+++ b/wrappers/run_llm_json_2d.py
@@ -19,6 +19,7 @@ from typing import Dict, List
 from openai import OpenAI, RateLimitError, APIError
 import backoff
 from .rate_limit import wait_one_second, set_tpm
+from .response_logger import log_response
 
 from generate import CAProblemGenerator2D, Problem2D
 from rules import Rule2D
@@ -55,6 +56,7 @@ def chat_json(model: str, prompt: str, temperature: float = 0.0):
     )
 
     raw = resp.choices[0].message.content
+    log_response(model, raw)
     parsed = extract_json_from_string(raw)
     if parsed is None:
         print(


### PR DESCRIPTION
## Summary
- Introduce `response_logger` module that writes timestamped raw responses and model name to `logs/responses.log`
- Log every model reply in `openai_v1.chat_once`, `run_llm_json.chat_json`, `run_llm_json_2d.chat_json`, and the one-call trial script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e153f83148330a68a8d79ffdb31fb