### PR TITLE
Enforce structured JSON responses via system prompts

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -35,6 +35,12 @@ for d in (DATA_DIR, LOG_DIR, RESULT_DIR):
 
 HARD_SPEND_CEILING = 5.00  # USD
 
+# System prompt for structured responses
+SYSTEM_PROMPT = (
+    "Respond with a JSON object containing keys 'initial_state' and 'final_state' "
+    "(alias 'answer'). Do not include any extra text outside the JSON."
+)
+
 # Helpers
 def shell(cmd: List[str]) -> None:
     """Run a subprocess and exit if it fails."""
@@ -191,6 +197,8 @@ def run(
                     "--output", str(jsonl_preds),
                     "--usage", str(usage_csv),
                     "--tpm", str(max_calls),
+                    "--temperature", "0",
+                    "--system", SYSTEM_PROMPT,
                 ]
                 if dry_run:
                     cmd.append("--dry-run")


### PR DESCRIPTION
## Summary
- Ensure orchestrator passes a deterministic system prompt and temperature 0 when invoking model wrappers
- Add default system prompts to `run_llm_json` and `run_llm_json_2d` forcing `initial_state`/`final_state` JSON keys
- Include system message in each OpenAI chat completion request alongside JSON response format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f69e9ea608330a9abe6897d7db665