### PR TITLE
Support `final_state` as fallback answer

### DIFF
--- a/convert_predictions.py
+++ b/convert_predictions.py
@@ -36,7 +36,10 @@ def json_to_bits(obj: dict) -> str:
     """
 
     if "answer" not in obj:
-        raise ValueError("missing 'answer' key")
+        if "final_state" in obj:
+            obj["answer"] = obj["final_state"]
+        else:
+            raise ValueError("missing 'answer' key")
 
     def _collect(x, sink):
         if isinstance(x, list):

--- a/wrappers/run_llm_json.py
+++ b/wrappers/run_llm_json.py
@@ -54,7 +54,7 @@ def chat_json(
     temperature: float = 0.0,
 ):
     """One JSON-mode call → (python_dict, token_usage, raw_text)."""
-    REQUIRED_KEYS = ("answer",)
+    REQUIRED_KEYS = ("answer", "final_state")
     total_usage = {"prompt": 0, "completion": 0, "total": 0}
     raw = ""
 
@@ -79,13 +79,15 @@ def chat_json(
         total_usage["total"] += u.total_tokens
 
         parsed = extract_json_from_string(raw)
-        if parsed is None or any(k not in parsed for k in REQUIRED_KEYS):
+        if parsed is None or not any(k in parsed for k in REQUIRED_KEYS):
             warn = "[warning] failed to parse JSON or missing keys;"
             if attempt < 4:
                 print(warn + " retrying", file=sys.stderr)
                 continue
             print(warn + " logging empty answer", file=sys.stderr)
             parsed = {"answer": []}
+        elif "answer" not in parsed and "final_state" in parsed:
+            parsed["answer"] = parsed["final_state"]
         break
 
     return parsed, total_usage, raw


### PR DESCRIPTION
## Summary
- Accept `final_state` when `answer` key is missing in JSON-mode wrappers
- Handle `final_state` responses in `convert_predictions.py`

## Testing
- `python convert_predictions.py --input sample_final_state.jsonl --output sample_output.pred`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892a89501588330a1a9264659649166